### PR TITLE
Updates

### DIFF
--- a/src/Eto.ExtendedRichTextArea/CaretBehavior.cs
+++ b/src/Eto.ExtendedRichTextArea/CaretBehavior.cs
@@ -32,7 +32,9 @@ class CaretBehavior
 		{
 			InvalidateCaret(_caretBounds);
 		}
-		_caretVisible = true;
+		// Only show caret if the control has focus
+		if (_textArea.HasFocus)
+			_caretVisible = true;
 		CalculateCaretBounds();
 		InvalidateCaret();
 		if (_textArea.Selection == null && updateSelectionAttributes)

--- a/src/Eto.ExtendedRichTextArea/ExtendedRichTextArea.cs
+++ b/src/Eto.ExtendedRichTextArea/ExtendedRichTextArea.cs
@@ -135,11 +135,15 @@ public class ExtendedRichTextArea : Scrollable
 		_drawable.Focus();
 	}
 
+	public new bool HasFocus => _drawable.HasFocus;
+
 	public ExtendedRichTextArea()
 	{
 		_drawable = new TextAreaDrawable(this);
 		_drawable.Caret.IndexChanged += Drawable_CaretIndexChanged;
 		_drawable.SelectionChanged += Drawable_SelectionChanged;
+		_drawable.GotFocus += (s, e) => OnGotFocus(e);
+		_drawable.LostFocus += (s, e) => OnLostFocus(e);
 
 		Content = _drawable;
 

--- a/src/Eto.ExtendedRichTextArea/ExtendedRichTextArea.cs
+++ b/src/Eto.ExtendedRichTextArea/ExtendedRichTextArea.cs
@@ -161,8 +161,8 @@ public class ExtendedRichTextArea : Scrollable
 		base.OnSizeChanged(e);
 		// When wrapping is enabled, we need to specify how much space we have
 		// It's not working just yet.
-		// if (_drawable != null)
-		// 	_drawable.Document.AvailableSize = ClientSize;
+		if (_drawable != null)
+			_drawable.Document.AvailableSize = ClientSize;
 	}
 
 	private void Drawable_CaretIndexChanged(object? sender, EventArgs e)

--- a/src/Eto.ExtendedRichTextArea/ExtendedRichTextArea.cs
+++ b/src/Eto.ExtendedRichTextArea/ExtendedRichTextArea.cs
@@ -35,6 +35,9 @@ public class ExtendedRichTextArea : Scrollable
 			if (_selectionAttributes != null)
 				_selectionAttributes.PropertyChanged -= SelectionAttributes_PropertyChanged;
 			_selectionAttributes = value;
+			// needs to be cleared otherwise applying 'bold' for example
+			// a 2nd time doesn't work.
+			_lastSelectionAttributes = null;
 			if (_selectionAttributes != null)
 				_selectionAttributes.PropertyChanged += SelectionAttributes_PropertyChanged;
 			SelectionAttributesChanged?.Invoke(this, EventArgs.Empty);

--- a/src/Eto.ExtendedRichTextArea/KeyboardBehavior.cs
+++ b/src/Eto.ExtendedRichTextArea/KeyboardBehavior.cs
@@ -250,8 +250,8 @@ class KeyboardBehavior
 			case Keys.Backspace:
 				if (_textArea.Selection?.Length > 0)
 				{
-					_textArea.Document.RemoveAt(_textArea.Selection.Start, _textArea.Selection.Length);
 					var start = _textArea.Selection.Start;
+					_textArea.Document.RemoveAt(_textArea.Selection.Start, _textArea.Selection.Length);
 					_caret.SetIndex(start, false);
 					_textArea.SetSelection(null, true);
 				}
@@ -267,8 +267,8 @@ class KeyboardBehavior
 			case Keys.Delete:
 				if (_textArea.Selection?.Length > 0)
 				{
-					_textArea.Document.RemoveAt(_textArea.Selection.Start, _textArea.Selection.Length);
 					var start = _textArea.Selection.Start;
+					_textArea.Document.RemoveAt(_textArea.Selection.Start, _textArea.Selection.Length);
 					_caret.SetIndex(start, false);
 					_textArea.SetSelection(null, true);
 				}

--- a/src/Eto.ExtendedRichTextArea/Model/Document.cs
+++ b/src/Eto.ExtendedRichTextArea/Model/Document.cs
@@ -54,14 +54,6 @@ public class Document : BlockContainerElement<IBlockElement>
 			throw new InvalidOperationException($"Failed to load document in {format.Name} format.");
 	}
 
-	protected override ContainerElement<IBlockElement> Clone()
-	{
-		var clone = (Document)base.Clone();
-		clone.ParagraphSpacing = ParagraphSpacing;
-		clone._defaultAttributes = _defaultAttributes?.Clone();
-		return clone;
-	}
-
 	int _suspendMeasure;
 	Attributes? _defaultAttributes;
 	float _screenScale = Screen.PrimaryScreen.Scale;
@@ -144,8 +136,22 @@ public class Document : BlockContainerElement<IBlockElement>
 		get => DefaultAttributes.Foreground ?? new SolidBrush(SystemColors.ControlText);
 		set => DefaultAttributes.Foreground = value;
 	}
+	
+	WrapMode _wrapMode;
 
-	public WrapMode WrapMode { get; internal set; }
+	public WrapMode WrapMode
+	{
+		get => _wrapMode;
+		set
+		{
+			if (_wrapMode != value)
+			{
+				_wrapMode = value;
+				MeasureIfNeeded();
+			}
+		}
+	}
+	
 	public event EventHandler<EventArgs>? Changing;
 
 	public DocumentRange GetRange(int start, int end)
@@ -382,4 +388,13 @@ public class Document : BlockContainerElement<IBlockElement>
 	}
 
 	internal float GetNextTabStop(float x) => TabStops?.GetNextTabStop(x) ?? FixedTabStops.DefaultTabStop - (int)x % FixedTabStops.DefaultTabStop;
+	
+	protected override ContainerElement<IBlockElement> Clone()
+	{
+		var clone = (Document)base.Clone();
+		clone.ParagraphSpacing = ParagraphSpacing;
+		clone._defaultAttributes = _defaultAttributes?.Clone();
+		clone._wrapMode = WrapMode;
+		return clone;
+	}
 }

--- a/src/Eto.ExtendedRichTextArea/Model/ParagraphElement.cs
+++ b/src/Eto.ExtendedRichTextArea/Model/ParagraphElement.cs
@@ -178,7 +178,7 @@ public class ParagraphElement : ContainerElement<IInlineElement>
 						available.Width,
 						idx => element.Measure(paragraphAttributes, available, inlineStart, idx, out baseline).Width);
 
-					if (wrapMode == Forms.WrapMode.Word && !string.IsNullOrEmpty(element.Text))
+					if (wrapMode == Forms.WrapMode.Word && element.Text?.Length > 0)
 					{
 						// split at word boundary if possible and re-measure new width
 						split.index = BackUpToWordBoundary(element.Text, inlineStart + split.index) - inlineStart;

--- a/src/Eto.ExtendedRichTextArea/Model/ParagraphElement.cs
+++ b/src/Eto.ExtendedRichTextArea/Model/ParagraphElement.cs
@@ -6,6 +6,25 @@ namespace Eto.ExtendedRichTextArea.Model;
 public class ParagraphElement : ContainerElement<IInlineElement>
 {
 	List<Line>? _lines;
+	WrapMode? _wrapMode;
+
+	public WrapMode? WrapMode
+	{
+		get => _wrapMode;
+		set
+		{
+			_wrapMode = value;
+			this.GetDocument()?.MeasureIfNeeded();
+		}
+	}
+
+	protected override ContainerElement<IInlineElement> Clone()
+	{
+		var clone = (ParagraphElement)base.Clone();
+		clone._wrapMode = _wrapMode;
+		return clone;
+	}
+
 
 	protected override ContainerElement<IInlineElement> Create() => new ParagraphElement();
 	protected override IInlineElement CreateElement() => new TextElement();
@@ -43,13 +62,47 @@ public class ParagraphElement : ContainerElement<IInlineElement>
 		return Bounds.Location;
 	}
 
+	public static (int index, float width) FindSplitIndex(int length, float maxWidth, Func<int, float> measure)
+	{
+		int lo = 0;
+		int hi = length; // inclusive upper bound via "lo < hi" pattern
+		float width = 0;
+
+		while (lo < hi)
+		{
+			int mid = (lo + hi + 1) / 2; // bias upward to avoid infinite loop
+			width = measure(mid);
+
+			if (width <= maxWidth)
+				lo = mid;
+			else
+				hi = mid - 1;
+		}
+
+		return (Math.Max(lo, 1), width);
+	}
+
+	public static int BackUpToWordBoundary(string text, int idx)
+	{
+		if (idx <= 0) return 0;
+		if (idx >= text.Length) return text.Length;
+
+		// If we're in the middle of a word, back up to whitespace.
+		int i = idx;
+		while (i > 0 && !char.IsWhiteSpace(text[i - 1]))
+			i--;
+
+		// If we backed up to 0 (single huge word), just split at idx.
+		return i == 0 ? idx : i;
+	}
+
 	static readonly char[] SpecialChars = new[] { SpecialCharacters.SoftBreakCharacter, SpecialCharacters.TabCharacter };
 	protected override SizeF MeasureOverride(Attributes defaultAttributes, SizeF availableSize, PointF location)
 	{
 		_lines ??= new List<Line>();
 		_lines.Clear();
 
-		availableSize += (SizeF)location;
+		// availableSize += (SizeF)location;
 		SizeF size = SizeF.Empty;
 		SizeF totalSize = SizeF.Empty;
 		int chunkStart = 0;
@@ -58,6 +111,8 @@ public class ParagraphElement : ContainerElement<IInlineElement>
 		PointF chunkLocation = location;
 		var line = new Line { Start = lineStart };
 		var paragraphAttributes = defaultAttributes.Merge(Attributes, false);
+		var document = this.GetDocument();
+		var wrapMode = WrapMode ?? document?.WrapMode ?? Forms.WrapMode.Word;
 		for (int i = 0; i < Count; i++)
 		{
 			if (i > 0)
@@ -83,7 +138,7 @@ public class ParagraphElement : ContainerElement<IInlineElement>
 					hasSoftBreak = true;
 				}
 
-				var available = availableSize - new SizeF(location.X, 0);
+				var available = availableSize - new SizeF(chunkLocation.X, 0);
 				var elementSize = element.Measure(paragraphAttributes, available, inlineStart, elementLength, out var baseline);
 
 				void NextLine()
@@ -101,41 +156,68 @@ public class ParagraphElement : ContainerElement<IInlineElement>
 					chunkStart = 0;
 				}
 
-				if (chunkLocation.X + elementSize.Width > availableSize.Width)
+				void AddChunk(Chunk chunk)
 				{
-					// TODO: this isn't quite done yet, but we need to split elements that are too wide for the line
-					if (chunkLocation.X <= availableSize.Width)
+					line.Add(chunk);
+					line.Baseline = Math.Max(line.Baseline, baseline);
+
+					size.Height = Math.Max(size.Height, chunk.Bounds.Height);
+					size.Width += chunk.Bounds.Width;
+					chunkLocation.X += chunk.Bounds.Width;
+
+					lineStart += chunk.Length;
+					chunkStart += chunk.Length;
+					inlineStart += chunk.Length;
+				}
+
+				if (wrapMode != Forms.WrapMode.None && elementSize.Width > available.Width)
+				{
+					// split into multiple chunks if it's too wide
+					var split = FindSplitIndex(
+						elementLength,
+						available.Width,
+						idx => element.Measure(paragraphAttributes, available, inlineStart, idx, out baseline).Width);
+
+					if (wrapMode == Forms.WrapMode.Word && !string.IsNullOrEmpty(element.Text))
 					{
-						// split into possibly multiple lines here (if one element is very long)
-						var chunk = new Chunk(element, chunkStart, elementLength, new RectangleF(chunkLocation, elementSize), inlineStart);
-						line.Add(chunk);
-						lineStart += elementLength;
+						// split at word boundary if possible and re-measure new width
+						split.index = BackUpToWordBoundary(element.Text, inlineStart + split.index) - inlineStart;
+						split.width = element.Measure(paragraphAttributes, available, inlineStart, split.index, out baseline).Width;
 					}
 
-					// new line for the rest of it!
-					NextLine();
+					// couldn't split, just add the whole thing
+					if (split.index <= 0 && chunkStart == 0)
+						split.index = elementLength;
+
+					if (split.index > 0)
+					{
+						elementSize.Width = split.width;
+						var chunk = new Chunk(element, chunkStart, split.index, new RectangleF(chunkLocation, elementSize), inlineStart);
+						AddChunk(chunk);
+					}
+
+					// new line for the rest of the text in the next iteration
+					if (split.index < elementLength)
+						NextLine();
 				}
 				else
 				{
 					var chunk = new Chunk(element, chunkStart, elementLength, new RectangleF(chunkLocation, elementSize), inlineStart);
-					line.Add(chunk);
+					AddChunk(chunk);
 				}
-				line.Baseline = Math.Max(line.Baseline, baseline);
-
-				size.Height = Math.Max(size.Height, elementSize.Height);
-				size.Width += elementSize.Width;
-				chunkLocation.X += elementSize.Width;
-
-				lineStart += elementLength;
-				chunkStart += elementLength;
-				inlineStart += elementLength;
 
 				if (hasTabStop)
 				{
 					var indent = GetNextTabStop(chunkLocation.X) - chunkLocation.X;
 
-					// add a chunk for the tab stop so it renders
 					elementSize.Width = indent;
+					if (chunkLocation.X + elementSize.Width > availableSize.Width)
+					{
+						// tab stop goes beyond the available width, so move to the next line
+						NextLine();
+					}
+					
+					// add a chunk for the tab stop so it renders
 					var chunk = new Chunk(element, chunkStart, 1, new RectangleF(chunkLocation, elementSize), inlineStart);
 					line.Add(chunk);
 
@@ -207,7 +289,7 @@ public class ParagraphElement : ContainerElement<IInlineElement>
 			if (lines.Length > 1)
 			{
 				var insertParagraph = this;
-				
+
 				for (int i = 0; i < lines.Length; i++)
 				{
 					if (i > 0)

--- a/src/Eto.ExtendedRichTextArea/TextAreaDrawable.cs
+++ b/src/Eto.ExtendedRichTextArea/TextAreaDrawable.cs
@@ -61,7 +61,7 @@ class TextAreaDrawable : Drawable
 
 	private void Document_OverrideAttributes(object? sender, OverrideAttributesEventArgs e)
 	{
-		if (Selection?.Length > 0)
+		if (Selection?.Length > 0 && HasFocus)
 			e.NewAttributes.Add(new AttributeRange(Selection.Start, Selection.End, HighlightAttributes));
 	}
 

--- a/src/Eto.ExtendedRichTextArea/TextAreaDrawable.cs
+++ b/src/Eto.ExtendedRichTextArea/TextAreaDrawable.cs
@@ -38,7 +38,11 @@ class TextAreaDrawable : Drawable
 			_document.OverrideAttributes += Document_OverrideAttributes;
 			_document.DefaultAttributesChanged += Document_DefaultAttributesChanged;
 			_document.Changing += Document_BeginEditEvent;
+			_selection = null; // Clear stale selection from previous document
 			_caret.SetIndex(0, true);
+			// Always refresh SelectionAttributes from the new document.
+			// SetIndex above may skip the update when the caret is already at 0.
+			_textArea.SelectionAttributes = _document.GetAttributes(0, 0);
 			Invalidate(false);
 			ClearUndoRedoStacks();
 		}

--- a/test/Eto.ExtendedRichTextArea.TestApp/MainForm.cs
+++ b/test/Eto.ExtendedRichTextArea.TestApp/MainForm.cs
@@ -54,6 +54,13 @@ namespace Eto.ExtendedRichTextArea.TestApp
 
 			return bitmap;
 		}
+		
+		Control WrapModeDropDown()
+		{
+			var dropDown = new EnumDropDown<WrapMode>();
+			dropDown.SelectedValueBinding.Bind(RichTextArea, r => r.Document.WrapMode);
+			return dropDown;
+		}
 
 		Control AttributeControls()
 		{
@@ -330,7 +337,7 @@ namespace Eto.ExtendedRichTextArea.TestApp
 			var layout = new DynamicLayout { Padding = new Padding(10), DefaultSpacing = new Size(4, 4) };
 			layout.Styles.Add(null, (Label lbl) => lbl.VerticalAlignment = VerticalAlignment.Center);
 
-			layout.AddSeparateRow(insertRandomTextButton, setSelectedText, insertImageButton, insertListButton, clearButton, null);
+			layout.AddSeparateRow(insertRandomTextButton, setSelectedText, insertImageButton, insertListButton, clearButton, "Wrap", WrapModeDropDown(), null);
 			layout.AddSeparateRow(AttributeControls(), null);
 			{
 				layout.BeginVertical();


### PR DESCRIPTION
- Wrapping support with Document.WordWrap and ParagraphElement.WordWrap
- Don't show selection when control does not have focus
- Clear selection state when setting a new document
- Set focus of drawable when ExtendedRichTextArea is set focus